### PR TITLE
Verify client signatures before signing

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -875,14 +875,14 @@ Expected to find the request at: $req_in"
 	verify_file req "$req_in" || die "\
 The certificate request file is not in a valid X509 request format.
 File Path: $req_in"
+	
+	openssl_easyrsa req -verify -in "$req_in" || die "Invalid signature"
 
 	# Display the request subject in an easy-to-read format
 	# Confirm the user wishes to sign this request
 	confirm "Confirm request details: " "yes" "
 You are about to sign the following certificate.
-Please check over the details shown below for accuracy. Note that this request
-has not been cryptographically verified. Please be sure it came from a trusted
-source or that you have verified the request checksum with the sender.
+Please check over the details shown below for accuracy.
 
 Request subject, to be signed as a $crt_type certificate for $EASYRSA_CERT_EXPIRE days:
 


### PR DESCRIPTION
Hi!

I was thrown off by the warning that "Note that this request has not been cryptographically verified." Could we just verify it first instead?

I mean, it's still a good idea to make sure that the a bad request hasn't been slipped in the middle. Bootstrapping that trust is the big hard problem, so maybe I should put back the "came from a trusted source" warning.  I think "verified the request checksum with the sender." could be more helpful if it came with the specific openssl commands to run on both sides to generate that checksum; in this first draft, I just dropped that line too, because it's a hard problem to solve.